### PR TITLE
VBump component version to 23.0.0

### DIFF
--- a/enhanced-dialog-demo/pom.xml
+++ b/enhanced-dialog-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-dialog-demo</artifactId>
     <packaging>war</packaging>
-    <version>22.0.6</version>
+    <version>23.0.0</version>
 
     <name>Component Factory Enhanced Dialog add-on Demo</name>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>enhanced-dialog</artifactId>
-            <version>22.0.6</version>
+            <version>23.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/enhanced-dialog-demo/pom.xml
+++ b/enhanced-dialog-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-dialog-demo</artifactId>
     <packaging>war</packaging>
-    <version>1.0.4</version>
+    <version>22.0.6</version>
 
     <name>Component Factory Enhanced Dialog add-on Demo</name>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>enhanced-dialog</artifactId>
-            <version>1.0.4</version>
+            <version>22.0.6</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/enhanced-dialog/pom.xml
+++ b/enhanced-dialog/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-dialog</artifactId>
-    <version>1.0.4</version>
+    <version>22.0.6</version>
     <name>Enhanced Dialog</name>
     <description>Integration of vcf-enhanced-dialog for Vaadin platform</description>
 

--- a/enhanced-dialog/pom.xml
+++ b/enhanced-dialog/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-dialog</artifactId>
-    <version>22.0.6</version>
+    <version>23.0.0</version>
     <name>Enhanced Dialog</name>
     <description>Integration of vcf-enhanced-dialog for Vaadin platform</description>
 

--- a/enhanced-dialog/src/main/java/com/vaadin/componentfactory/EnhancedDialog.java
+++ b/enhanced-dialog/src/main/java/com/vaadin/componentfactory/EnhancedDialog.java
@@ -41,7 +41,7 @@ import com.vaadin.flow.dom.Element;
  * @author Vaadin Ltd
  */
 @Tag("vcf-enhanced-dialog")
-@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-dialog", version = "22.0.6")
+@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-dialog", version = "23.0.0")
 @JsModule("@vaadin-component-factory/vcf-enhanced-dialog")
 @SuppressWarnings("serial")
 public class EnhancedDialog extends Dialog {

--- a/enhanced-dialog/src/main/java/com/vaadin/componentfactory/EnhancedDialog.java
+++ b/enhanced-dialog/src/main/java/com/vaadin/componentfactory/EnhancedDialog.java
@@ -41,7 +41,7 @@ import com.vaadin.flow.dom.Element;
  * @author Vaadin Ltd
  */
 @Tag("vcf-enhanced-dialog")
-@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-dialog", version = "1.0.7")
+@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-dialog", version = "22.0.6")
 @JsModule("@vaadin-component-factory/vcf-enhanced-dialog")
 @SuppressWarnings("serial")
 public class EnhancedDialog extends Dialog {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>enhanced-dialog-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0.4</version>
+	<version>22.0.6</version>
 
 	<name>Component Factory Enhanced Dialog add-on Root</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>enhanced-dialog-root</artifactId>
 	<packaging>pom</packaging>
-	<version>22.0.6</version>
+	<version>23.0.0</version>
 
 	<name>Component Factory Enhanced Dialog add-on Root</name>
 


### PR DESCRIPTION
This is to support upgrade to V22.0.6 after releasing a new component version.
https://github.com/vaadin-component-factory/vcf-enhanced-dialog/pull/5

Update: now targeting V23.0.0